### PR TITLE
Fix validation for coin history API days parameter

### DIFF
--- a/src/app/api/coin-history/route.ts
+++ b/src/app/api/coin-history/route.ts
@@ -67,10 +67,13 @@ export async function GET(req: Request) {
 
     // Decide which method to use
     const numericDays = Number(daysParam)
-    const isNumber = !Number.isNaN(numericDays)
+    const hasNumericDays = Number.isFinite(numericDays)
     const shouldUseRange =
-      (isNumber && (!allowedDays.has(numericDays) || numericDays > 365)) // custom/YTD/max-from-first-buy cases
-      || false
+      hasNumericDays && (!allowedDays.has(numericDays) || numericDays > 365) // custom/YTD/max-from-first-buy cases
+
+    if (daysParam !== 'max' && !hasNumericDays) {
+      return NextResponse.json({ error: 'Invalid days parameter' }, { status: 400 })
+    }
 
     let out:
       | { t: number; v: number }[]


### PR DESCRIPTION
## Summary
- ensure the coin history API rejects invalid non-numeric day ranges instead of forwarding NaN
- simplify the range detection logic by removing redundant checks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68decdbb17dc8322be5d42b6fcda1524