### PR TITLE
fix: cron route reads Vercel's Authorization: Bearer header

### DIFF
--- a/src/app/api/notifications/cron/route.ts
+++ b/src/app/api/notifications/cron/route.ts
@@ -26,7 +26,10 @@ function readCronSecret(req: NextRequest) {
   const url = new URL(req.url)
   const qs = (url.searchParams.get('secret') ?? '').trim()
   const hdr = (req.headers.get('x-cron-secret') ?? '').trim()
-  return hdr || qs
+  // Vercel cron sends the secret as "Authorization: Bearer <CRON_SECRET>"
+  const auth = (req.headers.get('authorization') ?? '').trim()
+  const bearer = auth.startsWith('Bearer ') ? auth.slice(7).trim() : ''
+  return bearer || hdr || qs
 }
 
 function getSupabaseAdmin() {


### PR DESCRIPTION
## Summary
- **Root cause found**: Vercel cron jobs send `CRON_SECRET` as `Authorization: Bearer <secret>`, but the cron route was only checking `x-cron-secret` header and `?secret=` query param
- Every automated 30-minute cron invocation was returning **401 Unauthorized** — silently preventing all live alert emails
- Test emails worked because they're triggered manually with `?secret=` in the URL

## What changed
- `src/app/api/notifications/cron/route.ts`: `readCronSecret()` now checks `Authorization: Bearer` header **first**, then falls back to `x-cron-secret` and `?secret=`

## Test plan
- [ ] After deploy, wait for next cron run (up to 30 min) — verify alert email arrives
- [ ] Or check Vercel function logs: cron invocation should return 200 instead of 401
- [ ] Manual `?secret=` and `x-cron-secret` header still work (backwards compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)