### PR TITLE
Self-host application fonts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,11 @@
       "name": "ledgerone-2.0",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource-variable/dm-sans": "^5.3.0",
+        "@fontsource-variable/ibm-plex-sans": "^5.3.0",
+        "@fontsource-variable/inter": "^5.3.0",
+        "@fontsource-variable/jetbrains-mono": "^5.3.0",
+        "@fontsource-variable/sora": "^5.3.0",
         "@supabase/ssr": "^0.7.0",
         "@supabase/supabase-js": "^2.74.0",
         "lucide-react": "^0.461.0",
@@ -761,6 +766,51 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fontsource-variable/dm-sans": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/dm-sans/-/dm-sans-5.3.0.tgz",
+      "integrity": "sha512-BpUG5bqePiDFMBM4ZtLSlPdAIOM990uB1dlXzIf4aw21yQR7BmykedLXXXMqGWsR18aMLOsbWccwJNh3ztTQaA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/ibm-plex-sans": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/ibm-plex-sans/-/ibm-plex-sans-5.3.0.tgz",
+      "integrity": "sha512-agG8tXFEo0hD9+J7npa4vbbWult52eMLVaQ6WQRlhs/iCAojrMAoejru85W9HTVXHfyUj96KM7gp/KGAS87XaQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.3.0.tgz",
+      "integrity": "sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/jetbrains-mono": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.3.0.tgz",
+      "integrity": "sha512-F32xpS2NsGYoQi2ADSkKTgpJj7ozajsGgDJ8woTnqjmIB+dxDIqImjl4pXZVEExu8UFZ2ndhmX18EBS/hdz3Lw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/sora": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/sora/-/sora-5.3.0.tgz",
+      "integrity": "sha512-h8kHta4Z8SkfUGeI82TUy1n3rbrKpBRGwuk4t4qCwto5oEHxlbOFD2yGP+Df5fbmTXwKGn+o667vYp0E4K8Whw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --runInBand"
   },
   "dependencies": {
+    "@fontsource-variable/dm-sans": "^5.3.0",
+    "@fontsource-variable/ibm-plex-sans": "^5.3.0",
+    "@fontsource-variable/inter": "^5.3.0",
+    "@fontsource-variable/jetbrains-mono": "^5.3.0",
+    "@fontsource-variable/sora": "^5.3.0",
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.74.0",
     "lucide-react": "^0.461.0",

--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -1,4 +1,3 @@
-import { Sora, DM_Sans, JetBrains_Mono } from 'next/font/google'
 import type { Viewport } from 'next'
 import { L1SiteAnimations } from '@/components/ledgerone'
 
@@ -16,30 +15,9 @@ export const viewport: Viewport = {
   viewportFit: 'cover',
 }
 
-const sora = Sora({
-  subsets: ['latin'],
-  weight: ['400', '500', '600', '700', '800'],
-  variable: '--l1-sora',
-  display: 'swap',
-})
-
-const dmSans = DM_Sans({
-  subsets: ['latin'],
-  weight: ['400', '500', '600', '700'],
-  variable: '--l1-dm-sans',
-  display: 'swap',
-})
-
-const jetbrainsMono = JetBrains_Mono({
-  subsets: ['latin'],
-  weight: ['400', '500', '600'],
-  variable: '--l1-jb-mono',
-  display: 'swap',
-})
-
 export default function MarketingLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className={`l1-marketing ${sora.variable} ${dmSans.variable} ${jetbrainsMono.variable}`}>
+    <div className="l1-marketing">
       <L1SiteAnimations />
       {children}
     </div>

--- a/src/app/csv/page.tsx
+++ b/src/app/csv/page.tsx
@@ -1,15 +1,10 @@
-import { Sora, DM_Sans, JetBrains_Mono } from 'next/font/google'
 import CSVClient from './CSVClient'
 import '../settings/settings-skin.css'
 import './csv-skin.css'
 
-const sora = Sora({ subsets: ['latin'], weight: ['400', '600', '700'], variable: '--st-sora', display: 'swap' })
-const dmSans = DM_Sans({ subsets: ['latin'], weight: ['400', '500', '600', '700'], variable: '--st-dmsans', display: 'swap' })
-const jbMono = JetBrains_Mono({ subsets: ['latin'], weight: ['400', '500'], variable: '--st-jbmono', display: 'swap' })
-
 export default function CSVPage() {
   return (
-    <div className={`st ${sora.variable} ${dmSans.variable} ${jbMono.variable}`}>
+    <div className="st">
       <div className="mx-auto w-full max-w-[920px]">
         <CSVClient />
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,23 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Self-hosted font packages keep production builds independent of Google Fonts.
+   These variables preserve the names consumed throughout the existing skins. */
+:root {
+  --font-inter: "Inter Variable", system-ui, sans-serif;
+  --font-sora: "Sora Variable", system-ui, sans-serif;
+  --font-plex: "IBM Plex Sans Variable", system-ui, sans-serif;
+  --l1-sora: "Sora Variable", system-ui, sans-serif;
+  --l1-dm-sans: "DM Sans Variable", system-ui, sans-serif;
+  --l1-jb-mono: "JetBrains Mono Variable", ui-monospace, monospace;
+  --ht-sora: "Sora Variable", system-ui, sans-serif;
+  --ht-dmsans: "DM Sans Variable", system-ui, sans-serif;
+  --ht-jbmono: "JetBrains Mono Variable", ui-monospace, monospace;
+  --st-sora: "Sora Variable", system-ui, sans-serif;
+  --st-dmsans: "DM Sans Variable", system-ui, sans-serif;
+  --st-jbmono: "JetBrains Mono Variable", ui-monospace, monospace;
+}
+
 /* Hard-stop any purple visited links globally */
 a, a:visited, a:hover, a:active {
   color: inherit;

--- a/src/app/how-to/how-to-skin.css
+++ b/src/app/how-to/how-to-skin.css
@@ -1,7 +1,7 @@
 /* ============================================================================
    How-to page — premium documentation skin.
    Scoped entirely under `.ht`. Type system (Sora / JetBrains Mono / DM Sans)
-   is injected via next/font on the .ht wrapper (see page.tsx).
+   is provided by the self-hosted font variables defined in globals.css.
    ========================================================================== */
 
 .ht {

--- a/src/app/how-to/page.tsx
+++ b/src/app/how-to/page.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link'
-import { Sora, DM_Sans, JetBrains_Mono } from 'next/font/google'
 import {
   LayoutDashboard,
   Wallet,
@@ -18,10 +17,6 @@ import {
 } from 'lucide-react'
 import '@/app/planner/planner-skin.css'
 import './how-to-skin.css'
-
-const sora = Sora({ subsets: ['latin'], weight: ['400', '600', '700', '800'], variable: '--ht-sora', display: 'swap' })
-const dmSans = DM_Sans({ subsets: ['latin'], weight: ['400', '500', '600', '700'], variable: '--ht-dmsans', display: 'swap' })
-const jbMono = JetBrains_Mono({ subsets: ['latin'], weight: ['400', '500', '600'], variable: '--ht-jbmono', display: 'swap' })
 
 /* ── Live demo: real planner-skin ladder ──────────────────────────────── */
 function DemoLadder() {
@@ -140,7 +135,7 @@ function Faq({ q, children }: { q: string; children: React.ReactNode }) {
 /* ────────────────────────────────────────────────────────────────────── */
 export default function HowToPage() {
   return (
-    <div className={`ht ${sora.variable} ${dmSans.variable} ${jbMono.variable}`}>
+    <div className="ht">
       {/* ── Hero ── */}
       <header className="ht-hero">
         <div className="ht-hero-aurora" aria-hidden="true" />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,15 @@
 import './globals.css'
 import './theme-light.css'
+import '@fontsource-variable/inter'
+import '@fontsource-variable/sora'
+import '@fontsource-variable/ibm-plex-sans'
+import '@fontsource-variable/dm-sans'
+import '@fontsource-variable/jetbrains-mono'
 import type { Metadata, Viewport } from 'next'
 import SWRProvider from '@/lib/swr'
 import AppShell from '@/components/common/AppShell'
 import PWAClient from '@/components/common/PWAClient'
 import { ThemeProvider } from '@/lib/theme'
-import { Inter, Sora, IBM_Plex_Sans } from 'next/font/google'
 
 // Runs synchronously before first paint so the stored theme is applied with no
 // flash. Marketing routes always keep the dark brand look (list mirrors
@@ -58,32 +62,9 @@ export const viewport: Viewport = {
   viewportFit: 'cover',
 }
 
-// Load Inter (weights you actually use; add/remove as needed)
-const inter = Inter({
-  subsets: ['latin'],
-  weight: ['400', '500', '600', '700'],
-  variable: '--font-inter',
-})
-
-// App design-system fonts (dashboard/planner/portfolio/coins/audit typography).
-// Sora = display/headings; IBM Plex Sans = ui/body/numbers (tabular-nums via tnum).
-// Weights match the uploaded skin's font loading exactly.
-const sora = Sora({
-  subsets: ['latin'],
-  weight: ['400', '500', '600', '700'],
-  variable: '--font-sora',
-  display: 'swap',
-})
-const ibmPlexSans = IBM_Plex_Sans({
-  subsets: ['latin'],
-  weight: ['400', '500', '600'],
-  variable: '--font-plex',
-  display: 'swap',
-})
-
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-<html lang="en" className={`${inter.variable} ${sora.variable} ${ibmPlexSans.variable} scrollbar-auto-hide`} suppressHydrationWarning>
+<html lang="en" className="scrollbar-auto-hide" suppressHydrationWarning>
       {/* Body background set to rgb(19,20,21) (#131415) */}
 <body className="antialiased font-sans bg-[#131415] overflow-x-hidden scrollbar-auto-hide">
         {/* Apply persisted theme before paint (no flash of the wrong theme) */}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,14 +1,9 @@
-import { Sora, DM_Sans, JetBrains_Mono } from 'next/font/google'
 import SettingsClient from './SettingsClient'
 import './settings-skin.css'
 
-const sora = Sora({ subsets: ['latin'], weight: ['400', '600', '700'], variable: '--st-sora', display: 'swap' })
-const dmSans = DM_Sans({ subsets: ['latin'], weight: ['400', '500', '600', '700'], variable: '--st-dmsans', display: 'swap' })
-const jbMono = JetBrains_Mono({ subsets: ['latin'], weight: ['400', '500'], variable: '--st-jbmono', display: 'swap' })
-
 export default function SettingsPage() {
   return (
-    <div className={`st ${sora.variable} ${dmSans.variable} ${jbMono.variable}`} data-settings-page>
+    <div className="st" data-settings-page>
       <SettingsClient />
     </div>
   )

--- a/src/app/settings/settings-skin.css
+++ b/src/app/settings/settings-skin.css
@@ -1,7 +1,7 @@
 /* ============================================================================
    Settings page — premium skin. Scoped under `.st`.
-   Type system (Sora / JetBrains Mono / DM Sans) injected via next/font on the
-   .st wrapper (see page.tsx). Shares the visual language of the how-to page.
+   Type system (Sora / JetBrains Mono / DM Sans) is provided by self-hosted
+   font variables. Shares the visual language of the how-to page.
    ========================================================================== */
 
 .st {


### PR DESCRIPTION
## What changed
- bundle Inter, Sora, IBM Plex Sans, DM Sans, and JetBrains Mono with the application
- remove all build-time Google Fonts downloads
- preserve the existing CSS font variables and typography

## Root cause
The Production redeployment failed when next/font could not download DM Sans from fonts.gstatic.com.

## Validation
- npm run build
- npm test (37/37 passing with the built server running)