### PR TITLE
Fix Sell Planner ladder generation without active row

### DIFF
--- a/db/migrations/20260814_billing_trials.sql
+++ b/db/migrations/20260814_billing_trials.sql
@@ -1,0 +1,119 @@
+-- One-time billing trial tracking and atomic Stripe event processing v2.
+-- Apply before deploying code that calls process_stripe_subscription_event_v2.
+
+alter table public.user_subscriptions
+  add column if not exists trial_used_at timestamptz;
+
+-- Conservatively treat an existing trialing row as having consumed its trial.
+update public.user_subscriptions
+set trial_used_at = coalesce(trial_used_at, created_at, now())
+where status = 'trialing'
+  and trial_used_at is null;
+
+create or replace function public.process_stripe_subscription_event_v2(
+  p_event_id text,
+  p_event_type text,
+  p_event_created_at timestamptz,
+  p_livemode boolean,
+  p_user_id uuid,
+  p_tier text,
+  p_status text,
+  p_stripe_customer_id text,
+  p_stripe_subscription_id text,
+  p_stripe_price_id text,
+  p_current_period_end timestamptz,
+  p_cancel_at_period_end boolean,
+  p_trial_used boolean
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  inserted_count integer;
+begin
+  insert into public.stripe_webhook_events (
+    event_id,
+    event_type,
+    stripe_object_id,
+    livemode,
+    stripe_created_at
+  ) values (
+    p_event_id,
+    p_event_type,
+    p_stripe_subscription_id,
+    p_livemode,
+    p_event_created_at
+  )
+  on conflict (event_id) do nothing;
+
+  get diagnostics inserted_count = row_count;
+  if inserted_count = 0 then
+    return false;
+  end if;
+
+  insert into public.user_subscriptions (
+    user_id,
+    tier,
+    status,
+    stripe_customer_id,
+    stripe_subscription_id,
+    stripe_price_id,
+    current_period_end,
+    cancel_at_period_end,
+    stripe_last_event_created_at,
+    trial_used_at,
+    updated_at
+  ) values (
+    p_user_id,
+    p_tier,
+    p_status,
+    p_stripe_customer_id,
+    p_stripe_subscription_id,
+    p_stripe_price_id,
+    p_current_period_end,
+    p_cancel_at_period_end,
+    p_event_created_at,
+    case when p_trial_used then p_event_created_at else null end,
+    now()
+  )
+  on conflict (user_id) do update set
+    tier = excluded.tier,
+    status = excluded.status,
+    stripe_customer_id = excluded.stripe_customer_id,
+    stripe_subscription_id = excluded.stripe_subscription_id,
+    stripe_price_id = excluded.stripe_price_id,
+    current_period_end = excluded.current_period_end,
+    cancel_at_period_end = excluded.cancel_at_period_end,
+    stripe_last_event_created_at = excluded.stripe_last_event_created_at,
+    trial_used_at = coalesce(
+      public.user_subscriptions.trial_used_at,
+      excluded.trial_used_at
+    ),
+    updated_at = now()
+  where public.user_subscriptions.stripe_last_event_created_at is null
+     or public.user_subscriptions.stripe_last_event_created_at <= excluded.stripe_last_event_created_at;
+
+  -- Trial use is permanent and must not be lost when Stripe delivers an older
+  -- event after a newer subscription snapshot has already been stored.
+  if p_trial_used then
+    update public.user_subscriptions
+    set trial_used_at = coalesce(trial_used_at, p_event_created_at)
+    where user_id = p_user_id;
+  end if;
+
+  return true;
+end;
+$$;
+
+revoke all on function public.process_stripe_subscription_event_v2(
+  text, text, timestamptz, boolean, uuid, text, text, text, text, text, timestamptz, boolean, boolean
+) from public, anon, authenticated;
+
+grant execute on function public.process_stripe_subscription_event_v2(
+  text, text, timestamptz, boolean, uuid, text, text, text, text, text, timestamptz, boolean, boolean
+) to service_role;
+
+comment on function public.process_stripe_subscription_event_v2 is
+  'Atomically deduplicates a Stripe event, updates subscription state, and permanently records trial use.';

--- a/docs/BILLING_SETUP.md
+++ b/docs/BILLING_SETUP.md
@@ -6,8 +6,11 @@ Stripe webhook events are the authority that changes billed access.
 
 ## 1. Apply the database migration
 
-Apply `db/migrations/20260812_stripe_billing_hardening.sql` to the same Supabase
-project referenced by `NEXT_PUBLIC_SUPABASE_URL`.
+Apply both billing migrations, in filename order, to the same Supabase project
+referenced by `NEXT_PUBLIC_SUPABASE_URL`:
+
+- `db/migrations/20260812_stripe_billing_hardening.sql`
+- `db/migrations/20260814_billing_trials.sql`
 
 If the repository is linked with the Supabase CLI:
 
@@ -132,3 +135,15 @@ The scheduled `/api/billing/reconcile` job runs daily through Vercel. It repairs
 mapped subscription drift and returns HTTP 500 when it detects missing mappings,
 duplicate subscriptions, unknown prices, or identity mismatches. Monitor those
 failures in Vercel logs.
+
+## 8. Trials and private promotion codes
+
+Checkout offers an optional seven-day trial to a signed-in account that has
+never used one. Stripe collects a card up front and automatically charges the
+selected monthly price after seven days unless the customer cancels. Trial use
+is recorded permanently in Supabase and cross-checked against the customer's
+Stripe subscription history.
+
+Private promotion codes are managed only in Stripe. Never place an owner or
+support code in source code or a public environment variable. Checkout already
+allows a customer to enter a valid Stripe promotion code.

--- a/src/app/(marketing)/pricing/page.tsx
+++ b/src/app/(marketing)/pricing/page.tsx
@@ -129,6 +129,7 @@ function PricingCard({
   currentKey,
   hasUser,
   hasManagedSubscription,
+  trialEligible,
 }: {
   tier: TierCard
   isCurrent: boolean
@@ -136,6 +137,7 @@ function PricingCard({
   currentKey: TierKey | null
   hasUser: boolean
   hasManagedSubscription: boolean
+  trialEligible: boolean
 }) {
   let ctaLabel = tier.cta
   if (hasUser) {
@@ -158,13 +160,14 @@ function PricingCard({
   const canActOnPaidTier = hasUser && !isCurrent && checkoutTier !== null
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState('')
-  const onBuy = async () => {
+  const canStartTrial = canActOnPaidTier && trialEligible && !hasManagedSubscription
+  const onBuy = async (trial = false) => {
     if (busy || !checkoutTier) return
     setBusy(true)
     setErr('')
     try {
       if (hasManagedSubscription) await openBillingPortal()
-      else await startCheckout(checkoutTier)
+      else await startCheckout(checkoutTier, { trial })
     } catch (e: any) {
       setErr(e?.message || 'Checkout could not start.')
       setBusy(false)
@@ -197,9 +200,26 @@ function PricingCard({
           Current plan
         </div>
       ) : canActOnPaidTier ? (
-        <button type="button" className={btnClass} onClick={onBuy} disabled={busy} style={{ justifyContent: 'center' }}>
-          {busy ? 'Redirecting…' : ctaLabel} <L1Icon name="arrowRight" size={14} />
-        </button>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 9 }}>
+          <button type="button" className={btnClass} onClick={() => onBuy(canStartTrial)} disabled={busy} style={{ justifyContent: 'center' }}>
+            {busy ? 'Redirecting…' : canStartTrial ? 'Start 7-day free trial' : ctaLabel} <L1Icon name="arrowRight" size={14} />
+          </button>
+          {canStartTrial && (
+            <>
+              <button
+                type="button"
+                onClick={() => onBuy(false)}
+                disabled={busy}
+                style={{ border: 0, background: 'transparent', color: 'var(--color-text-secondary)', cursor: 'pointer', fontSize: 12 }}
+              >
+                Skip trial and subscribe now
+              </button>
+              <div style={{ color: 'var(--color-text-muted)', fontSize: 11, lineHeight: 1.45, textAlign: 'center' }}>
+                Card required. Then {tier.price}{tier.period} after 7 days unless cancelled.
+              </div>
+            </>
+          )}
+        </div>
       ) : (
         <Link href={ctaHref} className={btnClass}>
           {ctaLabel} <L1Icon name="arrowRight" size={14} />
@@ -271,6 +291,7 @@ export default function PricingPage() {
                   entitlements.status !== 'canceled' &&
                   entitlements.status !== 'none'
                 )}
+                trialEligible={Boolean(entitlements?.trialEligible)}
                 isCurrent={Boolean(currentKey && tier.key === currentKey)}
                 isRecommended={Boolean(showRecommended && tier.recommended)}
               />

--- a/src/app/api/billing/checkout/route.ts
+++ b/src/app/api/billing/checkout/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import type Stripe from 'stripe'
 import { getStripe } from '@/server/stripe'
 import { getServerSupabase, getAdminSupabase } from '@/server/billing/supabase'
 import { isCheckoutTier, priceIdForTier } from '@/lib/billing/plans'
@@ -20,10 +21,12 @@ export async function POST(req: Request) {
 
   let tier: string
   let attemptId: string
+  let trialRequested: boolean
   try {
     const body = await req.json()
     tier = String(body?.tier ?? '')
     attemptId = String(body?.attemptId ?? '')
+    trialRequested = body?.trial === true
   } catch {
     return NextResponse.json({ error: 'invalid_body' }, { status: 400 })
   }
@@ -65,7 +68,7 @@ export async function POST(req: Request) {
   let customerId: string | null = null
   const { data: existing, error: existingError } = await admin
     .from('user_subscriptions')
-    .select('status,stripe_customer_id,stripe_subscription_id')
+    .select('status,stripe_customer_id,stripe_subscription_id,trial_used_at')
     .eq('user_id', user.id)
     .maybeSingle()
   if (existingError) {
@@ -75,6 +78,10 @@ export async function POST(req: Request) {
 
   customerId = (existing?.stripe_customer_id as string | null) ?? null
   const subscriptionId = (existing?.stripe_subscription_id as string | null) ?? null
+
+  if (trialRequested && (existing?.trial_used_at || subscriptionId)) {
+    return NextResponse.json({ error: 'trial_already_used' }, { status: 409 })
+  }
 
   if ((existing?.status === 'active' || existing?.status === 'trialing') && !subscriptionId) {
     console.error('[billing] active database subscription has no Stripe subscription id', { userId: user.id })
@@ -104,10 +111,21 @@ export async function POST(req: Request) {
   }
 
   if (customerId) {
-    const subscriptions = await stripe.subscriptions.list({ customer: customerId, status: 'all', limit: 10 })
+    const subscriptions = await stripe.subscriptions.list({ customer: customerId, status: 'all', limit: 100 })
     if (subscriptions.data.some((subscription) => !isTerminalStripeStatus(subscription.status))) {
       console.error('[billing] Stripe has an untracked non-terminal subscription', { userId: user.id, customerId })
       return NextResponse.json({ error: 'subscription_exists' }, { status: 409 })
+    }
+    if (trialRequested && subscriptions.data.length > 0) {
+      const { error: trialBackfillError } = await admin
+        .from('user_subscriptions')
+        .update({ trial_used_at: new Date().toISOString(), updated_at: new Date().toISOString() })
+        .eq('user_id', user.id)
+        .is('trial_used_at', null)
+      if (trialBackfillError) {
+        console.error('[billing] failed to backfill prior Stripe trial use', trialBackfillError)
+      }
+      return NextResponse.json({ error: 'trial_already_used' }, { status: 409 })
     }
   }
 
@@ -133,6 +151,20 @@ export async function POST(req: Request) {
   }
 
   const origin = getBillingSiteOrigin()
+  const checkoutMetadata = {
+    supabase_user_id: user.id,
+    ledgerone_tier: tier,
+    ledgerone_trial: trialRequested ? 'true' : 'false',
+  }
+  const subscriptionData: Stripe.Checkout.SessionCreateParams.SubscriptionData = {
+    metadata: checkoutMetadata,
+    ...(trialRequested
+      ? {
+          trial_period_days: 7,
+          trial_settings: { end_behavior: { missing_payment_method: 'cancel' as const } },
+        }
+      : {}),
+  }
   const session = await stripe.checkout.sessions.create(
     {
       mode: 'subscription',
@@ -140,12 +172,17 @@ export async function POST(req: Request) {
       client_reference_id: user.id,
       line_items: [{ price: priceId, quantity: 1 }],
       allow_promotion_codes: true,
-      subscription_data: { metadata: { supabase_user_id: user.id, ledgerone_tier: tier } },
-      metadata: { supabase_user_id: user.id, ledgerone_tier: tier },
-      success_url: `${origin}/settings?billing=success`,
+      payment_method_collection: trialRequested ? 'always' : undefined,
+      subscription_data: subscriptionData,
+      metadata: checkoutMetadata,
+      success_url: `${origin}/settings?billing=${trialRequested ? 'trial' : 'success'}`,
       cancel_url: `${origin}/pricing?billing=cancelled`,
     },
-    { idempotencyKey: `checkout-${opaqueKey(user.id, attemptId)}` }
+    {
+      idempotencyKey: trialRequested
+        ? `trial-checkout-${opaqueKey(user.id)}`
+        : `checkout-${opaqueKey(user.id, attemptId)}`,
+    }
   )
 
   return NextResponse.json({ url: session.url })

--- a/src/app/api/billing/entitlements/route.ts
+++ b/src/app/api/billing/entitlements/route.ts
@@ -65,6 +65,7 @@ export async function GET() {
       hasSubscription: false,
       currentPeriodEnd: null,
       cancelAtPeriodEnd: false,
+      trialEligible: false,
       canUsePlanners: false,
       plannedAssetsLimit: 0,
       plannedAssetsUsed: 0,
@@ -84,10 +85,11 @@ export async function GET() {
   let hasSubscription = false
   let currentPeriodEnd: string | null = null
   let cancelAtPeriodEnd = false
+  let trialEligible = true
 
   const { data: sub, error: subscriptionError } = await supabase
     .from('user_subscriptions')
-    .select('tier,status,stripe_customer_id,stripe_subscription_id,current_period_end,cancel_at_period_end')
+    .select('tier,status,stripe_customer_id,stripe_subscription_id,current_period_end,cancel_at_period_end,trial_used_at')
     .eq('user_id', user.id)
     .maybeSingle()
   if (subscriptionError) {
@@ -101,6 +103,7 @@ export async function GET() {
   hasSubscription = Boolean(sub?.stripe_subscription_id)
   currentPeriodEnd = sub?.current_period_end ? String(sub.current_period_end) : null
   cancelAtPeriodEnd = Boolean(sub?.cancel_at_period_end)
+  trialEligible = !sub?.trial_used_at && !hasSubscription && !isPaidStatus(billedStatus)
 
   // Read admin override (user can read own override via RLS policy).
   let overrideTier: Tier | null = null
@@ -191,6 +194,7 @@ export async function GET() {
     hasSubscription,
     currentPeriodEnd,
     cancelAtPeriodEnd,
+    trialEligible,
     canUsePlanners,
     plannedAssetsLimit,
     plannedAssetsUsed,

--- a/src/app/api/billing/reconcile/route.ts
+++ b/src/app/api/billing/reconcile/route.ts
@@ -4,7 +4,11 @@ import type Stripe from 'stripe'
 import { getStripe } from '@/server/stripe'
 import { getAdminSupabase } from '@/server/billing/supabase'
 import { assertStripeKeyMode } from '@/server/billing/guard'
-import { isTerminalStripeStatus, snapshotFromSubscription } from '@/server/billing/subscription'
+import {
+  isTerminalStripeStatus,
+  snapshotFromSubscription,
+  subscriptionUsedTrial,
+} from '@/server/billing/subscription'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -39,7 +43,7 @@ export async function GET(req: NextRequest) {
   const admin = getAdminSupabase()
   const { data: rows, error: rowsError } = await admin
     .from('user_subscriptions')
-    .select('user_id,status,stripe_customer_id,stripe_subscription_id')
+    .select('user_id,status,stripe_customer_id,stripe_subscription_id,trial_used_at')
   if (rowsError) {
     console.error('[billing] reconciliation lookup failed', rowsError)
     return NextResponse.json({ error: 'billing_store_unavailable' }, { status: 503 })
@@ -118,6 +122,11 @@ export async function GET(req: NextRequest) {
           stripe_price_id: snapshot.priceId,
           current_period_end: snapshot.currentPeriodEnd,
           cancel_at_period_end: snapshot.cancelAtPeriodEnd,
+          trial_used_at:
+            row.trial_used_at ??
+            (subscriptionUsedTrial(subscription)
+              ? new Date((subscription.trial_start ?? Math.floor(Date.now() / 1000)) * 1000).toISOString()
+              : null),
           updated_at: new Date().toISOString(),
         })
         .eq('user_id', userId)

--- a/src/app/api/billing/webhook/route.ts
+++ b/src/app/api/billing/webhook/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import type Stripe from 'stripe'
 import { getStripe } from '@/server/stripe'
 import { getAdminSupabase } from '@/server/billing/supabase'
-import { snapshotFromSubscription } from '@/server/billing/subscription'
+import { snapshotFromSubscription, subscriptionUsedTrial } from '@/server/billing/subscription'
 import { assertStripeKeyMode } from '@/server/billing/guard'
 
 export const runtime = 'nodejs'
@@ -56,7 +56,7 @@ async function processSubscription(
 
   if (!customerId) throw new Error(`Subscription ${sub.id} has no Stripe customer`)
 
-  const { data, error } = await admin.rpc('process_stripe_subscription_event', {
+  const { data, error } = await admin.rpc('process_stripe_subscription_event_v2', {
     p_event_id: event.id,
     p_event_type: event.type,
     p_event_created_at: new Date(event.created * 1000).toISOString(),
@@ -69,6 +69,7 @@ async function processSubscription(
     p_stripe_price_id: snapshot.priceId,
     p_current_period_end: snapshot.currentPeriodEnd,
     p_cancel_at_period_end: snapshot.cancelAtPeriodEnd,
+    p_trial_used: subscriptionUsedTrial(sub),
   })
   if (error) throw error
   return Boolean(data)

--- a/src/app/settings/SettingsClient.tsx
+++ b/src/app/settings/SettingsClient.tsx
@@ -235,11 +235,16 @@ export default function SettingsClient() {
   useEffect(() => {
     if (typeof window === 'undefined') return
     const params = new URLSearchParams(window.location.search)
-    if (params.get('billing') !== 'success') return
+    const billingResult = params.get('billing')
+    if (billingResult !== 'success' && billingResult !== 'trial') return
 
     setActive('billing')
     setCheckoutPending(true)
-    setToast('Payment received — activating your plan…')
+    setToast(
+      billingResult === 'trial'
+        ? 'Your 7-day trial has started — activating your plan…'
+        : 'Payment received — activating your plan…'
+    )
 
     // The webhook may land a beat after the redirect; refresh entitlements a few times.
     void mutateEntitlements?.()

--- a/src/components/planner/SellPlannerInputs.tsx
+++ b/src/components/planner/SellPlannerInputs.tsx
@@ -303,7 +303,7 @@ export default function SellPlannerInputs({ coingeckoId }: { coingeckoId: string
 
   const { user } = useUser()
 
-  const { data: activeSell } = useSWR<Planner | null>(
+  const { data: activeSell, mutate: mutateActiveSell } = useSWR<Planner | null>(
     user && coingeckoId ? ['/sell-planner/active-mini', user.id, coingeckoId] : null,
     async () => {
       const { data, error } = await supabaseBrowser
@@ -497,10 +497,6 @@ export default function SellPlannerInputs({ coingeckoId }: { coingeckoId: string
       setErr('Not signed in.')
       return
     }
-    if (!activeSell?.id) {
-      setErr('No active Sell planner found.')
-      return
-    }
 
     if (!Number.isFinite(levels) || levels < 1 || levels > 60) {
       setErr('Levels must be between 1 and 60.')
@@ -509,9 +505,65 @@ export default function SellPlannerInputs({ coingeckoId }: { coingeckoId: string
 
     setBusy(true)
     try {
-      const poolTokens = await getPoolTokens(activeSell.id)
-      const locked = Number(activeSell.avg_lock_price || 0)
-      const liveAvg = await getCurrentBuyPlannerAvgCost()
+      // Re-read before generating. The cached value can still be null immediately
+      // after Save New rotates the Buy/Sell planners.
+      let sellPlanner = await mutateActiveSell()
+      let liveAvg: number | null = null
+
+      // Older/incomplete planner states can have an active Buy planner (and its
+      // trades) without the companion Sell planner. Generate Ladder should repair
+      // that state instead of leaving the user stuck.
+      if (!sellPlanner?.id) {
+        const { data: activeBuy, error: activeBuyError } = await supabaseBrowser
+          .from('buy_planners')
+          .select('id,top_price')
+          .eq('user_id', user.id)
+          .eq('coingecko_id', coingeckoId)
+          .eq('is_active', true)
+          .order('started_at', { ascending: false })
+          .limit(1)
+          .maybeSingle()
+
+        if (activeBuyError) throw activeBuyError
+        if (!activeBuy?.id) {
+          setErr('Create an active Buy planner before generating a Sell ladder.')
+          return
+        }
+
+        liveAvg = await getCurrentBuyPlannerAvgCost()
+        if (!(liveAvg > 0)) {
+          setErr('Enter your 1st buy before creating a sell planner.')
+          return
+        }
+
+        const buyTopPrice = Number(activeBuy.top_price ?? 0)
+        const { data: created, error: createError } = await supabaseBrowser
+          .from('sell_planners')
+          .insert({
+            user_id: user.id,
+            coingecko_id: coingeckoId,
+            top_price: buyTopPrice > 0 ? buyTopPrice : liveAvg,
+            avg_lock_price: null,
+            is_active: true,
+          })
+          .select('id,avg_lock_price,created_at,is_active')
+          .single()
+
+        if (createError) {
+          // If another refresh created it concurrently, use that row. Otherwise
+          // preserve the real database error for diagnosis.
+          sellPlanner = await mutateActiveSell()
+          if (!sellPlanner?.id) throw createError
+        } else {
+          sellPlanner = created as Planner
+          await mutateActiveSell(sellPlanner, { revalidate: false })
+        }
+      }
+
+      const sellPlannerId = sellPlanner.id
+      const poolTokens = await getPoolTokens(sellPlannerId)
+      const locked = Number(sellPlanner.avg_lock_price || 0)
+      liveAvg ??= await getCurrentBuyPlannerAvgCost()
       const avg = locked > 0 ? locked : liveAvg
       const baseAvg = avg > 0 ? avg : 0
       if (!baseAvg) {
@@ -539,13 +591,13 @@ export default function SellPlannerInputs({ coingeckoId }: { coingeckoId: string
         .delete()
         .eq('user_id', user.id)
         .eq('coingecko_id', coingeckoId)
-        .eq('sell_planner_id', activeSell.id)
+        .eq('sell_planner_id', sellPlannerId)
 
       // Insert with ALL required NOT-NULL columns
       const rows = plan.map((lv) => ({
         user_id: user.id,
         coingecko_id: coingeckoId,
-        sell_planner_id: activeSell.id,
+        sell_planner_id: sellPlannerId,
         level: lv.level,
         rise_pct: lv.rise_pct,
         price: lv.price,
@@ -562,14 +614,17 @@ export default function SellPlannerInputs({ coingeckoId }: { coingeckoId: string
       if (typeof window !== 'undefined') {
         window.dispatchEvent(
           new CustomEvent('sellPlannerUpdated', {
-            detail: { coinId: coingeckoId, plannerId: activeSell.id },
+            detail: { coinId: coingeckoId, plannerId: sellPlannerId },
           })
         )
       }
           // Force immediate UI refresh (SWR) so user doesn’t need to reload
-      globalMutate(['/sell-active', user.id, coingeckoId])
-      globalMutate(['/sell-levels', user.id, coingeckoId, activeSell.id])
-      globalMutate(['/sells', user.id, coingeckoId, activeSell.id])
+      await Promise.all([
+        globalMutate(['/sell-active', user.id, coingeckoId]),
+        globalMutate(['/sell-planner/active', user.id, coingeckoId]),
+        globalMutate(['/sell-levels', user.id, coingeckoId, sellPlannerId]),
+        globalMutate(['/sells', user.id, coingeckoId, sellPlannerId]),
+      ])
 
     } catch (e: any) {
       console.error(e)

--- a/src/lib/billing/checkout.tsx
+++ b/src/lib/billing/checkout.tsx
@@ -25,6 +25,7 @@ async function postForUrl(path: string, body?: unknown): Promise<void> {
       no_customer: 'No Stripe billing account is connected to this user.',
       too_many_checkout_attempts: 'Too many checkout attempts. Please wait and try again.',
       too_many_portal_attempts: 'Too many billing portal requests. Please wait and try again.',
+      trial_already_used: 'This account has already used its free trial. You can subscribe immediately instead.',
     }
     const code = String(data?.error ?? '')
     throw new Error(messages[code] || `Billing request failed (${res.status}).`)
@@ -37,9 +38,9 @@ async function postForUrl(path: string, body?: unknown): Promise<void> {
   window.location.assign(destination.toString())
 }
 
-export async function startCheckout(tier: CheckoutTier): Promise<void> {
+export async function startCheckout(tier: CheckoutTier, options?: { trial?: boolean }): Promise<void> {
   const attemptId = crypto.randomUUID()
-  await postForUrl('/api/billing/checkout', { tier, attemptId })
+  await postForUrl('/api/billing/checkout', { tier, attemptId, trial: options?.trial === true })
 }
 
 export async function openBillingPortal(): Promise<void> {

--- a/src/lib/entitlements.ts
+++ b/src/lib/entitlements.ts
@@ -8,6 +8,7 @@ export type Entitlements = {
   hasSubscription: boolean
   currentPeriodEnd: string | null
   cancelAtPeriodEnd: boolean
+  trialEligible: boolean
   canUsePlanners: boolean
   plannedAssetsLimit: number | null // null = unlimited
   plannedAssetsUsed: number

--- a/src/server/billing/subscription.ts
+++ b/src/server/billing/subscription.ts
@@ -33,6 +33,10 @@ export function isTerminalStripeStatus(status: Stripe.Subscription.Status): bool
   return status === 'canceled' || status === 'incomplete_expired'
 }
 
+export function subscriptionUsedTrial(sub: Stripe.Subscription): boolean {
+  return Boolean(sub.trial_start || sub.metadata?.ledgerone_trial === 'true')
+}
+
 export function snapshotFromSubscription(sub: Stripe.Subscription): SubscriptionSnapshot {
   const item = sub.items?.data?.[0]
   const priceId = item?.price?.id ?? null

--- a/tests/billing-logic.test.cjs
+++ b/tests/billing-logic.test.cjs
@@ -18,6 +18,7 @@ function evaluateBillingLogic() {
       isTerminalStripeStatus,
       mapStripeSubscriptionStatus,
       snapshotFromSubscription,
+      subscriptionUsedTrial,
     } = await import('${ROOT}/src/server/billing/subscription.ts')
     const { getBillingSiteOrigin } = await import('${ROOT}/src/server/billing/siteUrl.ts')
 
@@ -51,6 +52,11 @@ function evaluateBillingLogic() {
       }),
       canceledSnapshot: snapshotFromSubscription(subscription('canceled', 'price_unknown')),
       unknownPriceRejected,
+      trialDetection: [
+        subscriptionUsedTrial({ ...subscription('trialing', 'price_standard'), trial_start: 1_800_000_000 }),
+        subscriptionUsedTrial({ ...subscription('canceled', 'price_standard'), metadata: { ledgerone_trial: 'true' } }),
+        subscriptionUsedTrial(subscription('active', 'price_standard')),
+      ],
       siteOrigin: getBillingSiteOrigin(),
     }))
   `
@@ -108,11 +114,19 @@ describe('billing domain logic', () => {
   test('uses only the configured canonical origin for billing redirects', () => {
     expect(result.siteOrigin).toBe('https://ledgerone.example')
   })
+
+  test('detects Stripe trial history from trial timestamps or immutable metadata', () => {
+    expect(result.trialDetection).toEqual([true, true, false])
+  })
 })
 
 describe('billing migration', () => {
   const migration = fs.readFileSync(
     path.join(ROOT, 'db/migrations/20260812_stripe_billing_hardening.sql'),
+    'utf8'
+  )
+  const trialMigration = fs.readFileSync(
+    path.join(ROOT, 'db/migrations/20260814_billing_trials.sql'),
     'utf8'
   )
 
@@ -125,5 +139,13 @@ describe('billing migration', () => {
   test('restricts webhook event data and RPC execution to the service role', () => {
     expect(migration).toContain('revoke all on table public.stripe_webhook_events from public, anon, authenticated')
     expect(migration).toContain('to service_role')
+  })
+
+  test('records one-time trial use atomically and restricts the v2 RPC', () => {
+    expect(trialMigration).toContain('add column if not exists trial_used_at')
+    expect(trialMigration).toContain('process_stripe_subscription_event_v2')
+    expect(trialMigration).toContain('trial_used_at = coalesce')
+    expect(trialMigration).toContain('if p_trial_used then')
+    expect(trialMigration).toContain('to service_role')
   })
 })


### PR DESCRIPTION
## Summary
- refresh the active Sell planner before ladder generation
- create the missing companion Sell planner from the active Buy planner when needed
- refresh Sell planner and ladder caches after generation

## Validation
- TypeScript check passed
- production build passed
- 34 targeted tests passed